### PR TITLE
Resolves various issues with Realms search

### DIFF
--- a/MobileRealmStatus/Controllers/RealmSearchController.swift
+++ b/MobileRealmStatus/Controllers/RealmSearchController.swift
@@ -1,28 +1,22 @@
-import UIKit
+import Foundation
 
-class RealmSearchController: NSObject, UISearchResultsUpdating {
+struct RealmSearchController {
     let realms: [Realm]
     let viewController: RealmsSearchDelegate
 
-    init(realms: [Realm], viewController: RealmsSearchDelegate) {
-        self.realms = realms
-        self.viewController = viewController
-    }
-
-    func updateSearchResultsForSearchController(searchController: UISearchController) {
-        let searchTerm = searchController.searchBar.text
+    func search(searchTerm: String) {
         let filteredRealms: [Realm]
 
         if searchTerm.isEmpty {
             filteredRealms = realms
         } else {
-            filteredRealms = search(searchTerm)
+            filteredRealms = filterRealms(searchTerm)
         }
 
         viewController.realmsFiltered(filteredRealms)
     }
 
-    func search(term: String) -> [Realm] {
+    private func filterRealms(term: String) -> [Realm] {
         let predicate = NSPredicate(format: "self CONTAINS[c] %@", term)
         return realms.filter { predicate.evaluateWithObject($0.name) }
     }

--- a/MobileRealmStatus/Resources/Storyboards/Main.storyboard
+++ b/MobileRealmStatus/Resources/Storyboards/Main.storyboard
@@ -12,6 +12,11 @@
                         <rect key="frame" x="0.0" y="0.0" width="600" height="536"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <searchBar key="tableHeaderView" contentMode="redraw" id="Dxq-Mp-fY3">
+                            <rect key="frame" x="0.0" y="0.0" width="600" height="44"/>
+                            <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
+                            <textInputTraits key="textInputTraits"/>
+                        </searchBar>
                         <prototypes>
                             <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="Realm" textLabel="4L8-xb-tuS" detailTextLabel="pq3-85-9yH" rowHeight="77" style="IBUITableViewCellStyleSubtitle" id="TdD-3D-hJV" customClass="RealmCell" customModule="MobileRealmStatus" customModuleProvider="target">
                                 <autoresizingMask key="autoresizingMask"/>
@@ -40,8 +45,11 @@
                             <outlet property="delegate" destination="tgZ-Li-UPb" id="tsx-PB-4iU"/>
                         </connections>
                     </tableView>
-                    <extendedEdge key="edgesForExtendedLayout"/>
+                    <extendedEdge key="edgesForExtendedLayout" top="YES"/>
                     <navigationItem key="navigationItem" title="Add Realm" id="Sxz-Gs-2X0"/>
+                    <connections>
+                        <outlet property="searchBar" destination="Dxq-Mp-fY3" id="ave-VR-tQZ"/>
+                    </connections>
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="6VJ-uB-8LM" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
@@ -105,8 +113,9 @@
         <scene sceneID="0S2-fK-td6">
             <objects>
                 <navigationController automaticallyAdjustsScrollViewInsets="NO" id="OPL-1d-ZQW" sceneMemberID="viewController">
+                    <extendedEdge key="edgesForExtendedLayout" top="YES"/>
                     <toolbarItems/>
-                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="MAf-PY-hqF">
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" translucent="NO" id="MAf-PY-hqF">
                         <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>

--- a/MobileRealmStatus/ViewControllers/RealmsTableViewController.swift
+++ b/MobileRealmStatus/ViewControllers/RealmsTableViewController.swift
@@ -4,6 +4,8 @@ import Runes
 class RealmsTableViewController: UITableViewController {
     private let cellIdentifier = "Realm"
 
+    @IBOutlet weak var searchBar: UISearchBar!
+
     var favoriteRealmsController: FavoriteRealmsController?
     var searchResultsController = UISearchController()
     var searchResultsUpdater: RealmSearchController?
@@ -12,7 +14,8 @@ class RealmsTableViewController: UITableViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         realms = favoriteRealmsController.map { $0.realms } ?? []
-        searchResultsController = setupSearch()
+        searchResultsUpdater = RealmSearchController(realms: realms, viewController: self)
+        searchBar.delegate = self
     }
 
     // MARK: - Table view data source
@@ -49,18 +52,23 @@ class RealmsTableViewController: UITableViewController {
 
         tableView.reloadData()
     }
+}
 
-    private func setupSearch() -> UISearchController {
-        searchResultsUpdater = RealmSearchController(realms: realms, viewController: self)
+extension RealmsTableViewController: UISearchBarDelegate {
+    func searchBarTextDidBeginEditing(searchBar: UISearchBar) {
+        navigationController?.setNavigationBarHidden(true, animated: true)
+        searchBar.showsCancelButton = true
+    }
 
-        let searchController = UISearchController(searchResultsController: nil)
-        searchController.searchResultsUpdater = searchResultsUpdater
-        searchController.dimsBackgroundDuringPresentation = false
+    func searchBar(searchBar: UISearchBar, textDidChange searchText: String) {
+        searchResultsUpdater?.search(searchText)
+    }
 
-        searchController.searchBar.sizeToFit()
-        tableView.tableHeaderView = searchController.searchBar
-
-        return searchController
+    func searchBarCancelButtonClicked(searchBar: UISearchBar) {
+        searchBar.text = ""
+        searchBar.resignFirstResponder()
+        searchBar.showsCancelButton = false
+        navigationController?.setNavigationBarHidden(false, animated: true)
     }
 }
 


### PR DESCRIPTION
By setting translucent to false for the navigation bar the following
issues are resolved:
- Get rid of shadow that appears during transition between search and
  add realm.
- Realms do not appear behind status bar when scrolling through table

Unfortunately, this introduced bugs with search using
UISearchController. When setting the navigation bar to translucent, the
search bar would animate out of view. It appears this is an issue that
others have experienced with the UISearchController (among other
issues). The realms search now moves away from UISearchController in
favor of implementing a UISearchBar and the UISearchBarDelegate. We
avoided using deprecated UISearchDisplayController.

Resolves:

https://trello.com/c/mJoO3nPw
https://trello.com/c/TeiBEd7r
