### PR TITLE
Clean up explicit public declarations

### DIFF
--- a/WoW-Realm-Tracker/Controllers/FavoriteRealmsController.swift
+++ b/WoW-Realm-Tracker/Controllers/FavoriteRealmsController.swift
@@ -1,31 +1,31 @@
-public struct FavoriteRealmsController {
+struct FavoriteRealmsController {
     private let favoritesManager: FavoritesManager
-    public let realms: [Realm]
+    let realms: [Realm]
 
-    public init(realms: [Realm], favoritesManager: FavoritesManager? = .None) {
+    init(realms: [Realm], favoritesManager: FavoritesManager? = .None) {
         self.realms = realms
         self.favoritesManager = favoritesManager.map { $0 } ?? FavoritesList.sharedFavoritesList
     }
 
-    public var favoriteRealms: [Realm] {
+    var favoriteRealms: [Realm] {
         get {
             return realms.filter { self.favoritesManager.favorites.contains($0.name) }
         }
     }
 
-    public func addFavorite(realm: Realm) {
+    func addFavorite(realm: Realm) {
         favoritesManager.addFavorite(realm.name)
     }
 
-    public func unfavorite(realm: Realm) {
+    func unfavorite(realm: Realm) {
         favoritesManager.removeFavorite(realm.name)
     }
 
-    public func shouldShowEmptyState() -> Bool {
+    func shouldShowEmptyState() -> Bool {
         return favoritesManager.favorites.isEmpty
     }
 
-    public func realmIsFavorited(realm: Realm) -> Bool {
+    func realmIsFavorited(realm: Realm) -> Bool {
         return favoritesManager.favorites.contains(realm.name)
     }
 }

--- a/WoW-Realm-Tracker/Controllers/RealmsController.swift
+++ b/WoW-Realm-Tracker/Controllers/RealmsController.swift
@@ -1,14 +1,14 @@
 import Swish
 
-public struct RealmsController {
+struct RealmsController {
     let realmsDelegate: RealmsDelegate
     let client = APIClient()
 
-    public init(realmsDelegate: RealmsDelegate) {
+    init(realmsDelegate: RealmsDelegate) {
         self.realmsDelegate = realmsDelegate
     }
 
-    public func retrieveRealms() {
+    func retrieveRealms() {
         let request = RealmsRequest()
         client.performRequest(request, completionHandler: realmsDelegate.receivedRealms)
     }

--- a/WoW-Realm-Tracker/Models/Realm.swift
+++ b/WoW-Realm-Tracker/Models/Realm.swift
@@ -1,12 +1,12 @@
 import Runes
 import Argo
 
-public struct Realm {
-    public let name: String
-    public let type: String
-    public let status: Bool
+struct Realm {
+    let name: String
+    let type: String
+    let status: Bool
 
-    public init(name: String, type: String, status: Bool) {
+    init(name: String, type: String, status: Bool) {
         self.name = name
         self.type = type
         self.status = status
@@ -18,7 +18,7 @@ extension Realm: Decodable {
         return Realm(name: name, type: type, status: status)
     }
 
-    public static func decode(j: JSON) -> Decoded<Realm> {
+    static func decode(j: JSON) -> Decoded<Realm> {
         return create
             <^> j <| "name"
             <*> j <| "type"

--- a/WoW-Realm-Tracker/Protocols/FavoritesManager.swift
+++ b/WoW-Realm-Tracker/Protocols/FavoritesManager.swift
@@ -1,4 +1,4 @@
-public protocol FavoritesManager {
+protocol FavoritesManager {
     var favorites: [String] { get }
 
     func addFavorite(realmName: String)

--- a/WoW-Realm-Tracker/Protocols/RealmsDelegate.swift
+++ b/WoW-Realm-Tracker/Protocols/RealmsDelegate.swift
@@ -1,5 +1,5 @@
 import Result
 
-public protocol RealmsDelegate {
+protocol RealmsDelegate {
     func receivedRealms(response: Result<[Realm], NSError>)
 }

--- a/WoW-Realm-Tracker/ViewControllers/FavoritesViewController.swift
+++ b/WoW-Realm-Tracker/ViewControllers/FavoritesViewController.swift
@@ -1,5 +1,4 @@
 import UIKit
-import Runes
 import Result
 
 class FavoritesViewController: UITableViewController {
@@ -8,7 +7,7 @@ class FavoritesViewController: UITableViewController {
 
     private var favoriteRealms: [Realm] {
         get {
-            return (controller >>- { $0.favoriteRealms }) ?? []
+            return controller.flatMap { $0.favoriteRealms } ?? []
         }
     }
 

--- a/WoW-Realm-Tracker/ViewControllers/RealmsTableViewController.swift
+++ b/WoW-Realm-Tracker/ViewControllers/RealmsTableViewController.swift
@@ -1,5 +1,4 @@
 import UIKit
-import Runes
 
 class RealmsTableViewController: UITableViewController {
     private let cellIdentifier = "Realm"
@@ -38,7 +37,7 @@ class RealmsTableViewController: UITableViewController {
 
     override func tableView(tableView: UITableView, didSelectRowAtIndexPath indexPath: NSIndexPath) {
         let realm = realms[indexPath.row]
-        let isFavorited = (controller >>- { $0.realmIsFavorited(realm) }) ?? false
+        let isFavorited = controller.flatMap { $0.realmIsFavorited(realm) } ?? false
 
         if isFavorited {
             controller?.unfavorite(realm)


### PR DESCRIPTION
This was done when the code was extracted to a framework for sharing
between iOS and the Watch-extension. Since this is no longer the case,
we do not need to publicly expose all of the things.
