### PR TITLE
Reorganize tests after Swift 2.0 update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,18 @@ branches:
   only:
     master
 
-env: export LANG=en_US.UTF-8
-
-script: bin/test
-
 notifications:
   email: false
+
+osx_image: xcode7.1
+xcode_project: WoW-Realm-Tracker.xcodeproj
+xcode_scheme: WoW-Realm-Tracker
+xcode_sdk: iphonesimulator9.1
+script: bin/test
+
+cache:
+  directories: "Carthage"
+
+before_install:
+  - bin/install-carthage
+  - bin/carthage-bootstrap-if-needed

--- a/UnitTests/Fakes/FakeFavoritesManager.swift
+++ b/UnitTests/Fakes/FakeFavoritesManager.swift
@@ -1,3 +1,5 @@
+@testable import WoW_Realm_Tracker
+
 class FakeFavoritesManager: FavoritesManager {
     var favorites = [String]()
 

--- a/UnitTests/Fakes/FakeRealmsSearchDelegate.swift
+++ b/UnitTests/Fakes/FakeRealmsSearchDelegate.swift
@@ -1,3 +1,5 @@
+@testable import WoW_Realm_Tracker
+
 class FakeRealmsSearchDelegate: RealmsSearchDelegate {
     var filteredRealms = [Realm]()
 

--- a/UnitTests/Tests/Controllers/FavoriteRealmsControllerSpec.swift
+++ b/UnitTests/Tests/Controllers/FavoriteRealmsControllerSpec.swift
@@ -1,3 +1,4 @@
+@testable import WoW_Realm_Tracker
 import Quick
 import Nimble
 
@@ -7,7 +8,7 @@ class FavoriteRealmsControllerSpec: QuickSpec {
     override func spec() {
         describe("addFavorite") {
             it("adds the realm to the user's favorites") {
-                let realm = self.buildRealm("Arthas")
+                let realm = buildRealm("Arthas")
                 let favoritesManager = FakeFavoritesManager()
                 let favoriteRealmsController = FavoriteRealmsController(
                     realms: [realm],
@@ -22,7 +23,7 @@ class FavoriteRealmsControllerSpec: QuickSpec {
 
         describe("removeFavorite") {
             it("removes the given realm from the user's favorites") {
-                let realm = self.buildRealm("Arthas")
+                let realm = buildRealm("Arthas")
                 let favoritesManager = FakeFavoritesManager()
                 favoritesManager.addFavorite("Arthas")
 
@@ -40,7 +41,7 @@ class FavoriteRealmsControllerSpec: QuickSpec {
         describe("realmIsFavorited") {
             context("user has favorited the realm") {
                 it("returns true") {
-                    let realm = self.buildRealm("Arthas")
+                    let realm = buildRealm("Arthas")
                     let favoritesManager = FakeFavoritesManager()
                     let favoriteRealmsController = FavoriteRealmsController(
                         realms: [realm],
@@ -54,7 +55,7 @@ class FavoriteRealmsControllerSpec: QuickSpec {
 
             context("user has not favorited the realm") {
                 it("returns false") {
-                    let realm = self.buildRealm("Arthas")
+                    let realm = buildRealm("Arthas")
                     let favoritesManager = FakeFavoritesManager()
                     let favoriteRealmsController = FavoriteRealmsController(
                         realms: [realm],
@@ -81,7 +82,7 @@ class FavoriteRealmsControllerSpec: QuickSpec {
 
             context("user has favorited at least one realm") {
                 it("returns false") {
-                    let realm = self.buildRealm("Arthas")
+                    let realm = buildRealm("Arthas")
                     let favoritesMananager = FakeFavoritesManager()
                     favoritesMananager.addFavorite("Arthas")
                     let favoriteRealmsController = FavoriteRealmsController(
@@ -95,7 +96,9 @@ class FavoriteRealmsControllerSpec: QuickSpec {
         }
     }
 
-    private func buildRealm(name: String) -> Realm {
-        return Realm(name: name, type: "pvp", status: true)
-    }
+
+}
+
+private func buildRealm(name: String) -> Realm {
+    return Realm(name: name, type: .PvP, status: true)
 }

--- a/UnitTests/Tests/Controllers/RealmSearchControllerSpec.swift
+++ b/UnitTests/Tests/Controllers/RealmSearchControllerSpec.swift
@@ -1,6 +1,7 @@
-import UIKit
-import Quick
+@testable import WoW_Realm_Tracker
 import Nimble
+import Quick
+import UIKit
 
 class RealmSearchControllerSpec: QuickSpec {
     override func spec() {

--- a/UnitTests/Tests/Models/FavoritesListSpec.swift
+++ b/UnitTests/Tests/Models/FavoritesListSpec.swift
@@ -1,20 +1,17 @@
-import Quick
+@testable import WoW_Realm_Tracker
 import Nimble
+import Quick
 
 private let favoritesDefaultsKey = "favorites"
 
 class FavoritesListSpec: QuickSpec {
     private var defaults: NSUserDefaults {
-        get {
-            let defaults = NSUserDefaults(suiteName: "group.com.damiangalarza.realmtracker")
-            return defaults!
-        }
+        let defaults = NSUserDefaults(suiteName: "group.com.damiangalarza.realmtracker")
+        return defaults!
     }
 
     private var favorites: [String] {
-        get {
-            return defaults.objectForKey(favoritesDefaultsKey) as! [String]
-        }
+        return defaults.objectForKey(favoritesDefaultsKey) as! [String]
     }
 
     override func spec() {

--- a/WoW-Realm-Tracker.xcodeproj/project.pbxproj
+++ b/WoW-Realm-Tracker.xcodeproj/project.pbxproj
@@ -10,7 +10,7 @@
 		10316F86452F2FBCAB95DA31 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = CB33AC4B689E2E3FC87C7696 /* Images.xcassets */; };
 		220570741B12ABB200ADE4B3 /* Nimble.framework in Carthage Copy Files */ = {isa = PBXBuildFile; fileRef = 227DCF1A1B12AA8200BCE33A /* Nimble.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		220570751B12ABB800ADE4B3 /* Quick.framework in Carthage Copy Files */ = {isa = PBXBuildFile; fileRef = 227DCF1B1B12AA8200BCE33A /* Quick.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		22116D4F1BA8611100A6FFD3 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = AD86D0AEB85DAE73D0513B18 /* Main.storyboard */; settings = {ASSET_TAGS = (); }; };
+		22116D4F1BA8611100A6FFD3 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = AD86D0AEB85DAE73D0513B18 /* Main.storyboard */; };
 		221285CD1B097A7E002FA5B5 /* UIfont.swift in Sources */ = {isa = PBXBuildFile; fileRef = 221285CC1B097A7E002FA5B5 /* UIfont.swift */; };
 		2215F1E31B06E9CC00505FCD /* RealmCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2215F1E21B06E9CC00505FCD /* RealmCell.swift */; };
 		224FA16B1BD9761D0012CF95 /* Curry.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 224FA16A1BD9761D0012CF95 /* Curry.framework */; };
@@ -21,39 +21,32 @@
 		227DCF1C1B12AA8200BCE33A /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 227DCF1A1B12AA8200BCE33A /* Nimble.framework */; };
 		227DCF1D1B12AA8200BCE33A /* Quick.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 227DCF1B1B12AA8200BCE33A /* Quick.framework */; };
 		227DCF1E1B12AA9900BCE33A /* FakeRealmsSearchDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22BBC1971B0F699900DE700D /* FakeRealmsSearchDelegate.swift */; };
-		227DCF1F1B12AA9900BCE33A /* RealmSearchController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22F5B6F61B096B39008ED648 /* RealmSearchController.swift */; };
 		227DCF201B12AA9900BCE33A /* RealmSearchControllerSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22BBC1991B0F69A900DE700D /* RealmSearchControllerSpec.swift */; };
-		227DCF221B12AA9900BCE33A /* RealmsSearchDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22F5B6F01B0964CD008ED648 /* RealmsSearchDelegate.swift */; };
-		22A9F9C11B0F6FBA00E3D249 /* UIWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22F5B6E41B08427E008ED648 /* UIWindow.swift */; };
-		22A9F9C21B0F6FC800E3D249 /* UIColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22F5B6E61B084305008ED648 /* UIColor.swift */; };
-		22A9F9C31B0F6FCC00E3D249 /* UIfont.swift in Sources */ = {isa = PBXBuildFile; fileRef = 221285CC1B097A7E002FA5B5 /* UIfont.swift */; };
+		22ABB28D1BECFDAE007BA008 /* FavoriteRealmsControllerSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22AFCBD31B0FD8FE00D6DD6B /* FavoriteRealmsControllerSpec.swift */; };
+		22ABB28E1BECFDB4007BA008 /* FavoritesListSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22AFCBCE1B0FD46D00D6DD6B /* FavoritesListSpec.swift */; };
+		22ABB28F1BECFE2E007BA008 /* FakeFavoritesManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22AFCBD91B10E4E900D6DD6B /* FakeFavoritesManager.swift */; };
 		22AEDE8C1B2132150010349A /* EmptyState.xib in Resources */ = {isa = PBXBuildFile; fileRef = 22AEDE8B1B2132150010349A /* EmptyState.xib */; };
 		22AEDE8E1B2133140010349A /* EmptyStateViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22AEDE8D1B2133140010349A /* EmptyStateViewController.swift */; };
 		22AEDE901B2135060010349A /* UIViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22AEDE8F1B2135060010349A /* UIViewController.swift */; };
 		22BD75C31B17F6B800AB8E8D /* SVProgressHUD.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 22BD75C21B17F6B800AB8E8D /* SVProgressHUD.framework */; };
 		22C767801BD176B800D62EC6 /* Swish.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 22C7677F1BD176B800D62EC6 /* Swish.framework */; };
-		22C767821BD176D000D62EC6 /* RealmsRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22C767811BD176D000D62EC6 /* RealmsRequest.swift */; settings = {ASSET_TAGS = (); }; };
+		22C767821BD176D000D62EC6 /* RealmsRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22C767811BD176D000D62EC6 /* RealmsRequest.swift */; };
 		22C767841BD1772000D62EC6 /* Result.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 22C767831BD1772000D62EC6 /* Result.framework */; };
 		22E645C31B16B9640023931E /* RealmViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22E645C21B16B9640023931E /* RealmViewModel.swift */; };
-		22E645C71B16BF580023931E /* RealmViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22E645C21B16B9640023931E /* RealmViewModel.swift */; };
 		22E649291B06415000578AFD /* FavoritesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22E649281B06415000578AFD /* FavoritesViewController.swift */; };
-		22EB85001BA7C4D8004F2EE8 /* Realm.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22F5DFBA1AF86043002F37B1 /* Realm.swift */; settings = {ASSET_TAGS = (); }; };
-		22EB85011BA7C4D8004F2EE8 /* Realm.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22F5DFBA1AF86043002F37B1 /* Realm.swift */; settings = {ASSET_TAGS = (); }; };
-		22EB85021BA7C4ED004F2EE8 /* RealmsDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22A270A51B081D6900C28773 /* RealmsDelegate.swift */; settings = {ASSET_TAGS = (); }; };
-		22EB85031BA7C541004F2EE8 /* FavoriteRealmsController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22542EB51B0828F700145420 /* FavoriteRealmsController.swift */; settings = {ASSET_TAGS = (); }; };
-		22EB85041BA7C54D004F2EE8 /* FavoritesManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22AFCBD61B10E49900D6DD6B /* FavoritesManager.swift */; settings = {ASSET_TAGS = (); }; };
-		22EB85051BA7C556004F2EE8 /* RealmsController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2215F1E51B081CBB00505FCD /* RealmsController.swift */; settings = {ASSET_TAGS = (); }; };
-		22EB85071BA7C568004F2EE8 /* FavoritesList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 229F1DBA1B064C470025CD7B /* FavoritesList.swift */; settings = {ASSET_TAGS = (); }; };
-		22EB85081BA7C57C004F2EE8 /* FavoriteRealmsController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22542EB51B0828F700145420 /* FavoriteRealmsController.swift */; settings = {ASSET_TAGS = (); }; };
-		22EB85091BA7C58B004F2EE8 /* FavoritesManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22AFCBD61B10E49900D6DD6B /* FavoritesManager.swift */; settings = {ASSET_TAGS = (); }; };
-		22EB850A1BA7C593004F2EE8 /* FavoritesList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 229F1DBA1B064C470025CD7B /* FavoritesList.swift */; settings = {ASSET_TAGS = (); }; };
+		22EB85001BA7C4D8004F2EE8 /* Realm.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22F5DFBA1AF86043002F37B1 /* Realm.swift */; };
+		22EB85021BA7C4ED004F2EE8 /* RealmsDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22A270A51B081D6900C28773 /* RealmsDelegate.swift */; };
+		22EB85031BA7C541004F2EE8 /* FavoriteRealmsController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22542EB51B0828F700145420 /* FavoriteRealmsController.swift */; };
+		22EB85041BA7C54D004F2EE8 /* FavoritesManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22AFCBD61B10E49900D6DD6B /* FavoritesManager.swift */; };
+		22EB85051BA7C556004F2EE8 /* RealmsController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2215F1E51B081CBB00505FCD /* RealmsController.swift */; };
+		22EB85071BA7C568004F2EE8 /* FavoritesList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 229F1DBA1B064C470025CD7B /* FavoritesList.swift */; };
 		22F5B6E51B08427E008ED648 /* UIWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22F5B6E41B08427E008ED648 /* UIWindow.swift */; };
 		22F5B6E71B084305008ED648 /* UIColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22F5B6E61B084305008ED648 /* UIColor.swift */; };
 		22F5B6E91B084F65008ED648 /* AppearanceManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22F5B6E81B084F65008ED648 /* AppearanceManager.swift */; };
 		22F5B6F11B0964CD008ED648 /* RealmsSearchDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22F5B6F01B0964CD008ED648 /* RealmsSearchDelegate.swift */; };
 		22F5B6F71B096B39008ED648 /* RealmSearchController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22F5B6F61B096B39008ED648 /* RealmSearchController.swift */; };
 		22F5DFBF1AF860D9002F37B1 /* RealmsTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22F5DFBE1AF860D9002F37B1 /* RealmsTableViewController.swift */; };
-		22FC26821BDC87FC00D68EA4 /* FavoritesDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22FC26811BDC87FC00D68EA4 /* FavoritesDataSource.swift */; settings = {ASSET_TAGS = (); }; };
+		22FC26821BDC87FC00D68EA4 /* FavoritesDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22FC26811BDC87FC00D68EA4 /* FavoritesDataSource.swift */; };
 		32D45B7D3468CD1A61B9EEF2 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CFABA4ED8A5CBB54DC232F79 /* Foundation.framework */; };
 		5E9BBDBCCC8573D5B56DFAEC /* Settings.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 4E24E3251A184795B15E78DD /* Settings.bundle */; };
 		A048D804A76A8C487E6C4582 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8C64CF0C9C5FEFC69FD22B5 /* AppDelegate.swift */; };
@@ -609,18 +602,11 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				22ABB28E1BECFDB4007BA008 /* FavoritesListSpec.swift in Sources */,
+				22ABB28D1BECFDAE007BA008 /* FavoriteRealmsControllerSpec.swift in Sources */,
 				227DCF201B12AA9900BCE33A /* RealmSearchControllerSpec.swift in Sources */,
 				227DCF1E1B12AA9900BCE33A /* FakeRealmsSearchDelegate.swift in Sources */,
-				227DCF221B12AA9900BCE33A /* RealmsSearchDelegate.swift in Sources */,
-				227DCF1F1B12AA9900BCE33A /* RealmSearchController.swift in Sources */,
-				22EB85011BA7C4D8004F2EE8 /* Realm.swift in Sources */,
-				22EB85081BA7C57C004F2EE8 /* FavoriteRealmsController.swift in Sources */,
-				22EB85091BA7C58B004F2EE8 /* FavoritesManager.swift in Sources */,
-				22E645C71B16BF580023931E /* RealmViewModel.swift in Sources */,
-				22A9F9C31B0F6FCC00E3D249 /* UIfont.swift in Sources */,
-				22A9F9C21B0F6FC800E3D249 /* UIColor.swift in Sources */,
-				22A9F9C11B0F6FBA00E3D249 /* UIWindow.swift in Sources */,
-				22EB850A1BA7C593004F2EE8 /* FavoritesList.swift in Sources */,
+				22ABB28F1BECFE2E007BA008 /* FakeFavoritesManager.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -706,7 +692,7 @@
 				GCC_WARN_UNUSED_VALUE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				INSTALL_PATH = /Applications;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				ONLY_ACTIVE_ARCH = YES;
 				RUN_CLANG_STATIC_ANALYZER = YES;
 				SDKROOT = iphoneos;
@@ -813,7 +799,7 @@
 				GCC_WARN_UNUSED_VALUE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				INSTALL_PATH = /Applications;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				RUN_CLANG_STATIC_ANALYZER = YES;
 				SDKROOT = iphoneos;
 				VALIDATE_PRODUCT = YES;

--- a/WoW-Realm-Tracker/Resources/Storyboards/Main.storyboard
+++ b/WoW-Realm-Tracker/Resources/Storyboards/Main.storyboard
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="8191" systemVersion="14F27" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="OPL-1d-ZQW">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9059" systemVersion="14F27" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="OPL-1d-ZQW">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="8154"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9049"/>
     </dependencies>
     <scenes>
         <!--Add Realm-->

--- a/bin/carthage-bootstrap-if-needed
+++ b/bin/carthage-bootstrap-if-needed
@@ -1,0 +1,6 @@
+#!/usr/bin/env sh
+
+if ! diff Cartfile.resolved Carthage/Cartfile.resolved &>/dev/null; then
+  carthage bootstrap --platform iOS --no-use-binaries
+  cp Cartfile.resolved Carthage
+fi

--- a/bin/install-carthage
+++ b/bin/install-carthage
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+
+brew update
+brew install carthage

--- a/bin/test
+++ b/bin/test
@@ -1,5 +1,11 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 
 set -o pipefail
 
-xcodebuild test -workspace MobileRealmStatus.xcworkspace -scheme MobileRealmStatus -sdk iphonesimulator BUILD_ACTIVE_ARCH=NO | xcpretty -t -c
+xcrun xcodebuild \
+  -project WoW-Realm-Tracker.xcodeproj \
+  -scheme WoW-Realm-Tracker \
+  -sdk iphonesimulator \
+  test \
+  | xcpretty --color
+


### PR DESCRIPTION
- Some tests were not being run because they were no longer part of the
  UnitTests target
- Move to Swift 2.0's `@testable` keyword instead of adding testing
  dependencies to the target by hand
- Some minor test refactoring as well
